### PR TITLE
Fix platform type JSON for WWDC 2015 Session 112

### DIFF
--- a/WWDC/videos.json
+++ b/WWDC/videos.json
@@ -177,7 +177,7 @@
     "title": "Think Audacious",
     "description": "When Debbie Sterling heard from Steve Jobs at her Stanford graduation that she should",
     "video_url": "http://devstreaming.apple.com/videos/wwdc/2015/112lwa56zromr4h6uf0/112/hls_vod_mvp.m3u8",
-    "platform": 0
+    "platform": ""
   },
   {
     "order_id": 21,


### PR DESCRIPTION
This got changed to the number 0 which was causing a crash since the platform label that was being set in the UI was expecting a string.
