### PR TITLE
Error message when the videos fail to load, refactor, and play button support.

### DIFF
--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1359C35E1C894CF60008C290 /* PlayerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1359C35D1C894CF60008C290 /* PlayerViewController.m */; };
 		43D82BDE1C25ED45005549ED /* FavoritesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 43D82BDD1C25ED45005549ED /* FavoritesManager.m */; };
 		541C84B11BFA953500FE5B5D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 541C84B01BFA953500FE5B5D /* main.m */; };
 		541C84B41BFA953500FE5B5D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 541C84B31BFA953500FE5B5D /* AppDelegate.m */; };
@@ -21,6 +22,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1359C35C1C894CF60008C290 /* PlayerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlayerViewController.h; sourceTree = "<group>"; };
+		1359C35D1C894CF60008C290 /* PlayerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlayerViewController.m; sourceTree = "<group>"; };
 		43D82BDC1C25ED45005549ED /* FavoritesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FavoritesManager.h; sourceTree = "<group>"; };
 		43D82BDD1C25ED45005549ED /* FavoritesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FavoritesManager.m; sourceTree = "<group>"; };
 		541C84AC1BFA953500FE5B5D /* WWDC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WWDC.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +80,8 @@
 				541C84CB1BFAE25900FE5B5D /* VideoTableViewController.m */,
 				541C84CD1BFAE2F000FE5B5D /* VideoDetailViewController.h */,
 				541C84CE1BFAE2F000FE5B5D /* VideoDetailViewController.m */,
+				1359C35C1C894CF60008C290 /* PlayerViewController.h */,
+				1359C35D1C894CF60008C290 /* PlayerViewController.m */,
 				43D82BDC1C25ED45005549ED /* FavoritesManager.h */,
 				43D82BDD1C25ED45005549ED /* FavoritesManager.m */,
 				541C84AF1BFA953500FE5B5D /* Supporting Files */,
@@ -178,6 +183,7 @@
 				541C84B41BFA953500FE5B5D /* AppDelegate.m in Sources */,
 				541C84CF1BFAE2F000FE5B5D /* VideoDetailViewController.m in Sources */,
 				541C84B11BFA953500FE5B5D /* main.m in Sources */,
+				1359C35E1C894CF60008C290 /* PlayerViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WWDC/PlayerViewController.h
+++ b/WWDC/PlayerViewController.h
@@ -1,0 +1,16 @@
+//
+//  PlayerViewController.h
+//  WWDC
+//
+//  Created by James Rossfeld on 3/3/16.
+//  Copyright © 2016 Bronron Apps. All rights reserved.
+//
+
+#import <AVKit/AVKit.h>
+
+@interface PlayerViewController : AVPlayerViewController
+
+- (instancetype) initWithVideoURL:(NSString *)videoURL;
+- (void)play;
+
+@end

--- a/WWDC/PlayerViewController.m
+++ b/WWDC/PlayerViewController.m
@@ -1,0 +1,92 @@
+//
+//  PlayerViewController.m
+//  WWDC
+//
+//  Created by James Rossfeld on 3/3/16.
+//  Copyright © 2016 Bronron Apps. All rights reserved.
+//
+
+#import "PlayerViewController.h"
+
+@import AVKit;
+
+@interface PlayerViewController ()
+
+@property (nonatomic, strong) AVPlayerItem *playerItem;
+@property (nonatomic, strong) NSString *videoURL;
+@property (nonatomic, assign) BOOL isVideoPlaying;
+
+@end
+
+@implementation PlayerViewController
+
+- (instancetype) initWithVideoURL:(NSString *)videoURL {
+    if (self = [super init]) {
+        self.videoURL = videoURL;
+        [self prepareVideo];
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    if (self.isVideoPlaying) {
+        self.isVideoPlaying = NO;
+        [self.playerItem removeObserver:self forKeyPath:@"status"];
+    }
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+}
+
+- (void)prepareVideo {
+    NSURL *url = [NSURL URLWithString:self.videoURL];
+    if (url == nil) return;
+    
+    AVAsset *asset = [AVAsset assetWithURL:url];
+    self.playerItem = [AVPlayerItem playerItemWithAsset:asset];
+    self.player = [AVPlayer playerWithPlayerItem:self.playerItem];
+    
+    self.isVideoPlaying = YES;
+    [self.playerItem addObserver:self
+                      forKeyPath:@"status"
+                         options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial)
+                         context:NULL];
+}
+
+//Plays the video on selecting the Play Video button
+- (void)play
+{
+    [self.player play];
+}
+
+- (void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
+    if (object == self.playerItem && [keyPath isEqualToString:@"status"]) {
+        
+        // Handle video load failures.
+        if (self.playerItem.status == AVPlayerStatusFailed) {
+            UIAlertController * alert=  [UIAlertController
+                                         alertControllerWithTitle:@"Video Error"
+                                         message:@"There was an error loading the content."
+                                         preferredStyle:UIAlertControllerStyleAlert];
+            
+            [self presentViewController:alert animated:YES completion:NULL];
+        }
+        //NSLog(@"Status: %ld\n\n", (long)self.playerItem.status);
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+}
+
+
+
+
+
+@end

--- a/WWDC/VideoDetailViewController.m
+++ b/WWDC/VideoDetailViewController.m
@@ -9,6 +9,7 @@
 #import "VideoDetailViewController.h"
 #import "Header.h"
 #import "FavoritesManager.h"
+#import "PlayerViewController.h"
 
 @import AVKit;
 
@@ -20,12 +21,6 @@
 @property (nonatomic, weak) IBOutlet UILabel *descriptionLabel;
 @property (nonatomic, strong) NSDictionary *videoDictionary;
 
-@property (nonatomic, strong) AVPlayerItem *playerItem;
-@property (nonatomic, strong) AVPlayer *player;
-@property (nonatomic, strong) AVPlayerViewController *playerViewController;
-@property (nonatomic, assign) BOOL isVideoPlaying;
-
-
 @end
 
 @implementation VideoDetailViewController
@@ -33,19 +28,11 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.isVideoPlaying = NO;
     
     // When setupVideoDictionary is called from the TableView Controller, this VC has not yet loaded from NIB.
     // This causes a bug where the labels show their default NIB contents.
     // Calling this method in viewDidLoad should cause the Labels to populate after loading from NIB.
     [self setupVideoDictionaryObject:self.videoDictionary];
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-    if (self.isVideoPlaying) {
-        self.isVideoPlaying = NO;
-        [self.playerItem removeObserver:self forKeyPath:@"status"];
-    }
 }
 
 //Setup detail labels
@@ -134,40 +121,11 @@
 //Plays the video on selecting the Play Video button
 - (IBAction)playVideo:(id)sender
 {
-    NSURL *url = [NSURL URLWithString:self.videoDictionary[kVideoURLKey]];
-    AVAsset *asset = [AVAsset assetWithURL:url];
-    
-    self.playerItem = [AVPlayerItem playerItemWithAsset:asset];
-    [self.playerItem addObserver:self
-                      forKeyPath:@"status"
-                         options:(NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial)
-                         context:NULL];
-    
-    self.player = [AVPlayer playerWithPlayerItem:self.playerItem];
-    
-    self.playerViewController = [AVPlayerViewController new];
-    self.playerViewController.player = self.player;
-    
-    [self presentViewController:self.playerViewController animated:true completion:^{
-        self.isVideoPlaying = YES;
-        [self.player play];
+    NSString *videoURL = self.videoDictionary[kVideoURLKey];
+    PlayerViewController *playerVC = [[PlayerViewController alloc] initWithVideoURL:videoURL];
+    [self presentViewController:playerVC animated:YES completion:^{
+        [playerVC play];
     }];
-}
-
-- (void) observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *,id> *)change context:(void *)context {
-    if (object == self.playerItem && [keyPath isEqualToString:@"status"]) {
-
-        // Handle video load failures.
-        if (self.playerItem.status == AVPlayerStatusFailed) {
-            UIAlertController * alert=  [UIAlertController
-                                          alertControllerWithTitle:@"Video Error"
-                                          message:@"There was an error loading the content."
-                                          preferredStyle:UIAlertControllerStyleAlert];
-            
-            [self.playerViewController presentViewController:alert animated:YES completion:NULL];
-        }
-        //NSLog(@"Status: %ld\n\n", (long)self.playerItem.status);
-    }
 }
 
 

--- a/WWDC/VideoDetailViewController.m
+++ b/WWDC/VideoDetailViewController.m
@@ -118,6 +118,22 @@
     self.favButton.layer.cornerRadius = 8;
 }
 
+#pragma mark - Play/Pause Press
+
+- (void) pressesEnded:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event {
+    for (UIPress *press in presses)
+    {
+        if (press.type == UIPressTypePlayPause)
+        {
+            [self playVideo:nil];
+        }
+        else
+        {
+            [super pressesEnded:presses withEvent:event];
+        }
+    }
+}
+
 //Plays the video on selecting the Play Video button
 - (IBAction)playVideo:(id)sender
 {

--- a/WWDC/VideoTableViewController.m
+++ b/WWDC/VideoTableViewController.m
@@ -9,6 +9,7 @@
 #import "VideoTableViewController.h"
 #import "Header.h"
 #import "FavoritesManager.h"
+#import "PlayerViewController.h"
 
 @interface VideoTableViewController () <UIGestureRecognizerDelegate>
 @property (nonatomic, strong) NSArray *sectionArray;
@@ -40,7 +41,6 @@
     lpgr.minimumPressDuration = 1.0; //seconds
     lpgr.delegate = self;
     [self.tableView addGestureRecognizer:lpgr];
-
     
     //Select the first item.
     [self selectTheFirstItem];
@@ -206,6 +206,39 @@
     [self.tableView reloadSections:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.visibleArray.count)] withRowAnimation:UITableViewRowAnimationAutomatic];
     [self selectTheFirstItem];
 }
+
+#pragma mark - Play/Pause Press
+
+- (void) pressesEnded:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event {
+    for (UIPress *press in presses)
+    {
+        if (press.type == UIPressTypePlayPause)
+        {
+            [self playPausePress];
+        }
+        else
+        {
+            [super pressesEnded:presses withEvent:event];
+        }
+    }
+}
+
+- (void)playPausePress {
+    UITableViewCell *focusedCell = (UITableViewCell *)[UIScreen mainScreen].focusedView;
+    if (focusedCell) {
+        NSIndexPath *indexPath = [self.tableView indexPathForCell:focusedCell];
+        if (indexPath) {
+            // get the video to play
+            NSDictionary *videoDictionary = [self videoDictionaryForIndexPath:indexPath];
+            NSString *videoURL = videoDictionary[kVideoURLKey];
+            PlayerViewController *playerVC = [[PlayerViewController alloc] initWithVideoURL:videoURL];
+            [self presentViewController:playerVC animated:YES completion:^{
+                [playerVC play];
+            }];
+        }
+    }
+}
+
 
 
 #pragma mark - Long press / Toggle Favorite

--- a/WWDC/VideoTableViewController.m
+++ b/WWDC/VideoTableViewController.m
@@ -23,6 +23,8 @@
 {
     [super viewDidLoad];
     
+    self.tableView.remembersLastFocusedIndexPath = YES;
+    
     self.title = self.conference_id;
     
     NSArray *allVideos = [self readJSONFile];


### PR DESCRIPTION
Hi again,

A few more changes in the commit messages below. I noticed some of the AltConf videos aren't working right now, so I may go through and see if I can fix some later. For now, an alert will popup if the video fails to load.

I also set the flag on the table view so the focus goes back properly when you're jumping back and forth. The focus engine was selecting the bottom row without it set.
